### PR TITLE
Add car showcase section with four builds

### DIFF
--- a/index.html
+++ b/index.html
@@ -93,6 +93,7 @@
             <!-- Nav Links -->
             <div class="flex flex-wrap justify-center gap-6 md:gap-8">
                 <a href="#services" class="nav-link text-white hover:text-red-500">Services</a>
+                <a href="#showcase" class="nav-link text-white hover:text-red-500">Car Showcase</a>
                 <a href="#parts" class="nav-link text-white hover:text-red-500">Used Parts</a>
                 <a href="#inventory" class="nav-link text-white hover:text-red-500">Used Cars</a>
                 <a href="#merch" class="nav-link text-white hover:text-red-500">Merchandise</a>
@@ -216,7 +217,66 @@
             </div>
         </div>
     </section>
-    
+
+    <!-- Car Showcase Section -->
+    <section id="showcase" class="py-16 bg-black px-6">
+        <div class="container mx-auto">
+            <h2 class="text-3xl md:text-4xl font-bold text-white mb-12 text-center section-title">
+                CAR <span class="text-red-600">SHOWCASE</span>
+            </h2>
+
+            <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8">
+                <!-- Car 1 -->
+                <div class="bg-gray-900 rounded-lg overflow-hidden shadow-xl card-hover">
+                    <div class="h-48 bg-gray-800">
+                        <img src="https://images.unsplash.com/photo-1503376780353-7e6692767b70?ixlib=rb-4.0.3&auto=format&fit=crop&w=800&q=80"
+                             alt="Project Supra" class="w-full h-full object-cover">
+                    </div>
+                    <div class="p-4">
+                        <h3 class="text-xl font-bold text-white mb-2">Project Supra</h3>
+                        <p class="text-gray-400 text-sm">800HP turbo build with custom aero.</p>
+                    </div>
+                </div>
+
+                <!-- Car 2 -->
+                <div class="bg-gray-900 rounded-lg overflow-hidden shadow-xl card-hover">
+                    <div class="h-48 bg-gray-800">
+                        <img src="https://images.unsplash.com/photo-1511919884226-fd3cad34687c?ixlib=rb-4.0.3&auto=format&fit=crop&w=800&q=80"
+                             alt="Classic Mustang" class="w-full h-full object-cover">
+                    </div>
+                    <div class="p-4">
+                        <h3 class="text-xl font-bold text-white mb-2">Classic Mustang</h3>
+                        <p class="text-gray-400 text-sm">Restored 1967 fastback with modern tech.</p>
+                    </div>
+                </div>
+
+                <!-- Car 3 -->
+                <div class="bg-gray-900 rounded-lg overflow-hidden shadow-xl card-hover">
+                    <div class="h-48 bg-gray-800">
+                        <img src="https://images.unsplash.com/photo-1542365885-b5c77635c69b?ixlib=rb-4.0.3&auto=format&fit=crop&w=800&q=80"
+                             alt="Civic Type-R" class="w-full h-full object-cover">
+                    </div>
+                    <div class="p-4">
+                        <h3 class="text-xl font-bold text-white mb-2">Civic Type-R</h3>
+                        <p class="text-gray-400 text-sm">Track-ready setup with forged internals.</p>
+                    </div>
+                </div>
+
+                <!-- Car 4 -->
+                <div class="bg-gray-900 rounded-lg overflow-hidden shadow-xl card-hover">
+                    <div class="h-48 bg-gray-800">
+                        <img src="https://images.unsplash.com/photo-1517142089942-ba376ce32a0b?ixlib=rb-4.0.3&auto=format&fit=crop&w=800&q=80"
+                             alt="Subaru WRX STI" class="w-full h-full object-cover">
+                    </div>
+                    <div class="p-4">
+                        <h3 class="text-xl font-bold text-white mb-2">Subaru WRX STI</h3>
+                        <p class="text-gray-400 text-sm">Rally-inspired build with upgraded suspension.</p>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+
     <!-- Used Parts Section -->
     <section id="parts" class="py-16 bg-gray-900 px-6">
         <div class="container mx-auto">


### PR DESCRIPTION
## Summary
- add "Car Showcase" navigation link
- showcase four company-built cars with images and descriptions

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a5e3d480dc8332bc810a52e78ee16e