### PR TITLE
Improve README with step-by-step Windows install/setup guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,76 @@
+# RAD 2 Server Helper Script (Windows)
+
+This repository includes:
+
+- `run-rad2-server.bat` — a launcher you can double-click to run a RAD 2 server.
+
+## What you need to install (step by step)
+
+## 1) Install Java
+RAD 2 servers usually need Java (often Java 8 for older packs, sometimes Java 17 for newer server files).
+
+1. Download and install Java (Temurin/OpenJDK is fine).
+2. During install, enable adding Java to `PATH` if that option appears.
+3. Open **Command Prompt** and run:
+   ```bat
+   java -version
+   ```
+4. If you see a Java version, you are good.
+
+If `java` is not recognized, either:
+- reinstall Java and add it to PATH, or
+- edit `run-rad2-server.bat` and set:
+  ```bat
+  set "JAVA_EXE=C:\Path\To\java.exe"
+  ```
+
+## 2) Download your RAD 2 server files
+1. Get the RAD 2 server pack from the launcher/platform you use (CurseForge/FTB/etc.).
+2. Extract it to a folder, for example:
+   `C:\Minecraft\RAD2-Server`
+
+You should see files like `start.bat` and/or a server `.jar` in that folder.
+
+## 3) Add this launcher script
+1. Copy `run-rad2-server.bat` into the RAD 2 server folder (same folder as `start.bat` or server `.jar`).
+2. Right-click `run-rad2-server.bat` → **Edit**.
+3. Set RAM values near the top (example):
+   ```bat
+   set "MIN_RAM=4G"
+   set "MAX_RAM=8G"
+   ```
+
+## 4) Start the server
+1. Double-click `run-rad2-server.bat`.
+2. On first run, it will create/fix `eula.txt` to `eula=true` (if enabled in script).
+3. Wait for server startup to finish.
+
+## 5) Allow players to connect (optional but usually needed)
+If friends outside your home network will join:
+
+1. Set a static local IP for your server PC (recommended).
+2. Port-forward **25565 TCP** in your router to that local IP.
+3. Allow Java/Minecraft server through Windows Firewall when prompted.
+4. Share your public IP (or dynamic DNS hostname) with friends.
+
+For LAN-only play, no port forwarding is needed.
+
+## 6) Join the server
+- On the same PC: use `localhost`.
+- On same LAN: use server PC local IP (example `192.168.1.50`).
+- Over internet: use your public IP/domain.
+
+## Script settings you can change
+Inside `run-rad2-server.bat`:
+
+- `MIN_RAM` / `MAX_RAM` — Java memory allocation.
+- `JAVA_EXE` — `java` or full path to `java.exe`.
+- `AUTO_ACCEPT_EULA` — `true`/`false`.
+- `RESTART_ON_CRASH` — auto restart when server exits.
+- `RESTART_DELAY_SECONDS` — delay before restart.
+
+## Quick troubleshooting
+- **"Java was not found"**: run `java -version`, fix PATH or `JAVA_EXE`.
+- **Server closes instantly**: run script from Command Prompt to read errors.
+- **Out of memory / lag**: increase `MAX_RAM` carefully, close other apps.
+- **Friends cannot connect**: re-check port forwarding + firewall + correct IP.

--- a/run-rad2-server.bat
+++ b/run-rad2-server.bat
@@ -1,0 +1,85 @@
+@echo off
+setlocal enabledelayedexpansion
+
+REM ================================================================
+REM RAD 2 (Roguelike Adventures and Dungeons 2) server launcher
+REM Put this file inside your RAD2 server folder and double-click it.
+REM ================================================================
+
+REM --- Settings you can edit ---
+set "MIN_RAM=4G"
+set "MAX_RAM=8G"
+set "JAVA_EXE=java"
+set "AUTO_ACCEPT_EULA=true"
+set "RESTART_ON_CRASH=true"
+set "RESTART_DELAY_SECONDS=10"
+REM -----------------------------
+
+cd /d "%~dp0"
+
+echo [RAD2] Working directory: %CD%
+
+where "%JAVA_EXE%" >nul 2>nul
+if errorlevel 1 (
+  echo [RAD2] ERROR: Java was not found.
+  echo [RAD2] Install Java 8/17 (as required by your server pack),
+  echo [RAD2] or set JAVA_EXE to the full path of java.exe in this file.
+  pause
+  exit /b 1
+)
+
+if /i "%AUTO_ACCEPT_EULA%"=="true" (
+  if not exist "eula.txt" (
+    echo [RAD2] Creating eula.txt...
+    > "eula.txt" echo eula=true
+  ) else (
+    powershell -NoProfile -Command "(Get-Content 'eula.txt') -replace '^eula=false$','eula=true' | Set-Content 'eula.txt'"
+  )
+)
+
+set "START_SCRIPT="
+for %%F in (start.bat Start.bat ServerStart.bat run.bat launch.bat) do (
+  if exist "%%~F" set "START_SCRIPT=%%~F"
+)
+
+set "SERVER_JAR="
+if not defined START_SCRIPT (
+  for %%J in (forge-*.jar *server*.jar *universal*.jar) do (
+    if not defined SERVER_JAR set "SERVER_JAR=%%~J"
+  )
+)
+
+if not defined START_SCRIPT if not defined SERVER_JAR (
+  echo [RAD2] ERROR: Could not find a server start script or server jar.
+  echo [RAD2] Place this file in the RAD2 server root folder.
+  pause
+  exit /b 1
+)
+
+:run_server
+cls
+echo [RAD2] ===============================================
+echo [RAD2] Launching RAD2 server...
+echo [RAD2] Min RAM: %MIN_RAM%  Max RAM: %MAX_RAM%
+echo [RAD2] ===============================================
+
+if defined START_SCRIPT (
+  call "%START_SCRIPT%"
+) else (
+  "%JAVA_EXE%" -Xms%MIN_RAM% -Xmx%MAX_RAM% -jar "%SERVER_JAR%" nogui
+)
+
+set "EXIT_CODE=%ERRORLEVEL%"
+echo.
+echo [RAD2] Server process exited with code %EXIT_CODE%.
+
+if /i not "%RESTART_ON_CRASH%"=="true" goto done
+
+echo [RAD2] Restarting in %RESTART_DELAY_SECONDS% seconds... (Ctrl+C to stop)
+timeout /t %RESTART_DELAY_SECONDS% /nobreak >nul
+goto run_server
+
+:done
+echo [RAD2] Launcher finished.
+pause
+exit /b %EXIT_CODE%


### PR DESCRIPTION
### Motivation
- Provide a clear, beginner-friendly step-by-step walkthrough for Windows users who asked what to install and how to start a RAD 2 server. 
- Explain the Java requirement and how to verify or point the launcher to a specific `java.exe` to avoid startup failures. 
- Clarify where to place the included `run-rad2-server.bat`, how to configure RAM and restart behavior, and common networking/troubleshooting steps. 

### Description
- Rewrote `README.md` into an explicit step-by-step Windows setup guide that covers installing Java, verifying with `java -version`, downloading/extracting the RAD 2 server pack, and placing the launcher in the server folder. 
- Documented configurable script options in `run-rad2-server.bat` such as `MIN_RAM`, `MAX_RAM`, `JAVA_EXE`, `AUTO_ACCEPT_EULA`, `RESTART_ON_CRASH`, and `RESTART_DELAY_SECONDS`. 
- Added startup instructions, first-run `eula.txt` handling, basic networking guidance for LAN vs internet play (port-forwarding and firewall), and a short troubleshooting section for common issues. 

### Testing
- Rendered and inspected the resulting README with `nl -ba README.md | sed -n '1,220p'`, which displayed the new content as expected. 
- Generated the PR metadata (title/body) via the repository PR helper to validate the change summary, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6986732712f083329feb190711778276)